### PR TITLE
Fix awsImageExpires handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ Image.prototype._upload = function _upload(dest, version, cb) {
   };
 
   if (version.awsImageExpires) {
-    options.Expires = new Date(Date.now() + version.awsImageExpires);
+    options.Expires = new Date(Date.now() + version.awsImageExpires * 1000);
   }
 
   if (version.awsImageMaxAge) {


### PR DESCRIPTION
The example in the `README` uses `31536000` (365 days in seconds) for both the `awsImageExpires` and the `awsImageMaxAge` options.

I concluded that passing the same value for both options would upload images with the both `max-age` and `expires` a year from now.

However, since `Date.now*()` returns a value in milliseconds instead of seconds, we must multiply the provided value by `1000` to get the expected result. This PR addresses this issue.